### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -62,7 +62,7 @@ class syntax_plugin_googledrawing extends DokuWiki_Syntax_Plugin {
     }
 
 
-    public function handle($match, $state, $pos, &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
 
         $data = array(
                      'id'  => '1EJyBXdSdnJ1mi6h371GXWdL0lz0Oj0lO9vcq_burdfs',
@@ -110,7 +110,7 @@ class syntax_plugin_googledrawing extends DokuWiki_Syntax_Plugin {
     }
 
     // TODO: Clean up the image tag generated in this function
-    public function render($mode, &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         if($mode != 'xhtml') return false;
 
         $baseUrl = $this->getGoogleUrl();


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.